### PR TITLE
feat: host extension system for typed, permission-gated plugin operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend (tsc + lint)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: TypeScript check
+        run: pnpm tsc -b
+
+      - name: Lint
+        run: pnpm lint
+
+  rust:
+    name: Rust (cargo check + clippy)
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: rust-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: rust-${{ runner.os }}-
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install frontend dependencies
+        run: pnpm install
+
+      - name: Build MCP sidecar
+        run: bash scripts/build-mcp-sidecar.sh
+
+      - name: Cargo check
+        working-directory: src-tauri
+        run: cargo check
+
+      - name: Clippy
+        working-directory: src-tauri
+        run: cargo clippy -- -D warnings

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'packages/plugin-sdk/src/client/**/*.gen.ts']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -20,6 +20,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +120,17 @@ name = "async-stream-impl"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -212,6 +237,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "borsh"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +429,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -747,12 +799,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -905,6 +957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +1032,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1101,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1095,6 +1178,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1520,7 +1614,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2022,6 +2116,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f66fe41fa46a5c83ed1c717b7e0b4635988f427083108c8cf0a882cc13441"
+dependencies = [
+ "ahash 0.8.12",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex-syntax",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,11 +2426,13 @@ name = "nexus"
 version = "0.1.0"
 dependencies = [
  "async-stream",
+ "async-trait",
  "axum",
  "bollard",
  "chrono",
  "dirs",
  "futures-util",
+ "jsonschema",
  "log",
  "reqwest 0.12.28",
  "serde",
@@ -2350,10 +2471,80 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.0"
+name = "num"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2716,6 +2907,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "pango"
@@ -3270,6 +3467,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0dcb5ab28989ad7c91eb1b9531a37a1a137cc69a0499aee4117cae4a107c464"
+dependencies = [
+ "ahash 0.8.12",
+ "fluent-uri",
+ "once_cell",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,7 +3526,9 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -4697,9 +4909,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -4707,22 +4919,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5161,6 +5373,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5183,6 +5406,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vswhom"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,3 +42,5 @@ tar = "0.4"
 utoipa = { version = "5", features = ["axum_extras"] }
 sha2 = "0.10"
 async-stream = "0.3"
+async-trait = "0.1"
+jsonschema = "0.28"

--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -1,0 +1,79 @@
+use crate::extensions::registry::ExtensionRegistry;
+use crate::extensions::RiskLevel;
+use crate::permissions::Permission;
+use crate::AppState;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtensionOperationStatus {
+    pub name: String,
+    pub description: String,
+    pub risk_level: RiskLevel,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtensionConsumer {
+    pub plugin_id: String,
+    pub plugin_name: String,
+    pub granted: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtensionStatus {
+    pub id: String,
+    pub display_name: String,
+    pub description: String,
+    pub operations: Vec<ExtensionOperationStatus>,
+    pub consumers: Vec<ExtensionConsumer>,
+}
+
+#[tauri::command]
+pub async fn extension_list(
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<ExtensionStatus>, String> {
+    let mgr = state.read().await;
+
+    let mut result = Vec::new();
+
+    for ext_info in mgr.extensions.list() {
+        let operations: Vec<ExtensionOperationStatus> = ext_info
+            .operations
+            .iter()
+            .map(|op| ExtensionOperationStatus {
+                name: op.name.clone(),
+                description: op.description.clone(),
+                risk_level: op.risk_level,
+            })
+            .collect();
+
+        // Find which installed plugins consume this extension
+        let mut consumers = Vec::new();
+        for plugin in mgr.storage.list() {
+            if let Some(ops) = plugin.manifest.extensions.get(&ext_info.id) {
+                // Check if all extension permissions for this plugin are granted
+                let all_granted = ops.iter().all(|op_name| {
+                    let perm_str =
+                        ExtensionRegistry::permission_string(&ext_info.id, op_name);
+                    let perm = Permission::Extension(perm_str);
+                    mgr.permissions.has_permission(&plugin.manifest.id, &perm)
+                });
+
+                consumers.push(ExtensionConsumer {
+                    plugin_id: plugin.manifest.id.clone(),
+                    plugin_name: plugin.manifest.name.clone(),
+                    granted: all_granted,
+                });
+            }
+        }
+
+        result.push(ExtensionStatus {
+            id: ext_info.id,
+            display_name: ext_info.display_name,
+            description: ext_info.description,
+            operations,
+            consumers,
+        });
+    }
+
+    Ok(result)
+}

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -115,13 +115,13 @@ pub async fn mcp_list_tools(
 
         for tool in &mcp_config.tools {
             let tool_disabled =
-                plugin_mcp.map_or(false, |s| s.disabled_tools.contains(&tool.name));
+                plugin_mcp.is_some_and(|s| s.disabled_tools.contains(&tool.name));
 
             let all_perms_granted = tool.permissions.iter().all(|perm_str| {
                 serde_json::from_value::<crate::permissions::Permission>(
                     serde_json::Value::String(perm_str.clone()),
                 )
-                .map_or(false, |perm| {
+                .is_ok_and(|perm| {
                     mgr.permissions.has_permission(&plugin.manifest.id, &perm)
                 })
             });

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod extensions;
 pub mod marketplace;
 pub mod mcp;
 pub mod permissions;

--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -74,21 +74,18 @@ pub async fn runtime_approval_respond(
     context: std::collections::HashMap<String, String>,
 ) -> Result<(), String> {
     // Persist the approved path before unblocking the handler
-    if decision == ApprovalDecision::Approve {
-        if category == "filesystem" {
-            if let Some(parent_dir) = context.get("parent_dir") {
-                let permission_str = context.get("permission").cloned().unwrap_or_default();
-                let permission: Permission =
-                    serde_json::from_value(serde_json::Value::String(permission_str))
-                        .map_err(|e| format!("invalid permission: {}", e))?;
+    if decision == ApprovalDecision::Approve && category == "filesystem" {
+        if let Some(parent_dir) = context.get("parent_dir") {
+            let permission_str = context.get("permission").cloned().unwrap_or_default();
+            let permission: Permission =
+                serde_json::from_value(serde_json::Value::String(permission_str))
+                    .map_err(|e| format!("invalid permission: {}", e))?;
 
-                let mut mgr = state.write().await;
-                mgr.permissions
-                    .add_approved_path(&plugin_id, &permission, parent_dir.clone())
-                    .map_err(|e| e.to_string())?;
-            }
+            let mut mgr = state.write().await;
+            mgr.permissions
+                .add_approved_path(&plugin_id, &permission, parent_dir.clone())
+                .map_err(|e| e.to_string())?;
         }
-        // Future categories (e.g. "network") persist their own data here
     }
 
     bridge.respond(&request_id, decision);

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -1,0 +1,90 @@
+pub mod registry;
+pub mod validation;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Risk level for an extension operation, determining whether runtime approval is needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RiskLevel {
+    Low,
+    Medium,
+    High,
+}
+
+/// Describes a single operation that an extension exposes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationDef {
+    /// Machine name, e.g. "refresh_credentials"
+    pub name: String,
+    /// Human-readable description
+    pub description: String,
+    /// How dangerous is this operation
+    pub risk_level: RiskLevel,
+    /// JSON Schema for the input object (must have "type": "object" at root)
+    pub input_schema: Value,
+}
+
+/// Successful result from executing an operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationResult {
+    /// Whether the operation succeeded
+    pub success: bool,
+    /// Operation output data
+    pub data: Value,
+    /// Optional human-readable message
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// Errors that can occur when executing an extension operation.
+#[derive(Debug, thiserror::Error)]
+pub enum ExtensionError {
+    #[error("Unknown operation: {0}")]
+    UnknownOperation(String),
+
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
+    #[error("Execution failed: {0}")]
+    ExecutionFailed(String),
+
+    #[error("Command failed (exit code {exit_code}): {stderr}")]
+    CommandFailed {
+        exit_code: i32,
+        stderr: String,
+    },
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+/// The core extension trait. Each extension is a Rust module implementing this trait,
+/// registered at startup, and exposed via the Host API.
+///
+/// Extensions are pure infrastructure — they provide capabilities, not user-facing tools.
+/// Only plugins expose MCP tools and UIs. The call chain is:
+/// AI → MCP sidecar → Plugin MCP tool → Host API /v1/extensions/{ext}/{op} → Extension → host CLI
+#[async_trait]
+pub trait Extension: Send + Sync + 'static {
+    /// Unique identifier, e.g. "weather" or "file_sync"
+    fn id(&self) -> &'static str;
+
+    /// Human-readable name, e.g. "Weather Service"
+    fn display_name(&self) -> &'static str;
+
+    /// Short description of what this extension provides
+    fn description(&self) -> &'static str;
+
+    /// List all operations this extension supports
+    fn operations(&self) -> Vec<OperationDef>;
+
+    /// Execute a named operation with the given JSON input.
+    /// Input will already be validated against the operation's input_schema before this is called.
+    async fn execute(&self, operation: &str, input: Value) -> Result<OperationResult, ExtensionError>;
+}

--- a/src-tauri/src/extensions/registry.rs
+++ b/src-tauri/src/extensions/registry.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+use serde::Serialize;
+use super::{Extension, OperationDef};
+
+/// Stores all registered extensions, built at startup.
+pub struct ExtensionRegistry {
+    extensions: HashMap<String, Box<dyn Extension>>,
+}
+
+/// Serializable summary of an extension for the list API.
+#[derive(Debug, Serialize)]
+pub struct ExtensionInfo {
+    pub id: String,
+    pub display_name: String,
+    pub description: String,
+    pub operations: Vec<OperationDef>,
+}
+
+impl ExtensionRegistry {
+    pub fn new() -> Self {
+        Self {
+            extensions: HashMap::new(),
+        }
+    }
+
+    /// Register an extension. Panics if an extension with the same ID is already registered.
+    pub fn register(&mut self, ext: Box<dyn Extension>) {
+        let id = ext.id().to_string();
+        if self.extensions.contains_key(&id) {
+            panic!("Duplicate extension ID: {}", id);
+        }
+        log::info!("Registered extension: {} ({})", ext.display_name(), id);
+        self.extensions.insert(id, ext);
+    }
+
+    /// Look up an extension by ID.
+    pub fn get(&self, id: &str) -> Option<&dyn Extension> {
+        self.extensions.get(id).map(|b| b.as_ref())
+    }
+
+    /// List all registered extensions with their operations.
+    pub fn list(&self) -> Vec<ExtensionInfo> {
+        let mut result: Vec<_> = self.extensions.values().map(|ext| ExtensionInfo {
+            id: ext.id().to_string(),
+            display_name: ext.display_name().to_string(),
+            description: ext.description().to_string(),
+            operations: ext.operations(),
+        }).collect();
+        result.sort_by(|a, b| a.id.cmp(&b.id));
+        result
+    }
+
+    /// Generate the permission string for an extension operation.
+    /// Format: "ext:{extension_id}:{operation_name}"
+    pub fn permission_string(ext_id: &str, operation: &str) -> String {
+        format!("ext:{}:{}", ext_id, operation)
+    }
+
+    /// Get all permission strings for all operations across all extensions.
+    pub fn all_permission_strings(&self) -> Vec<String> {
+        self.extensions.values().flat_map(|ext| {
+            let id = ext.id();
+            ext.operations().into_iter().map(move |op| {
+                Self::permission_string(id, &op.name)
+            })
+        }).collect()
+    }
+
+    /// Check if an extension+operation pair is valid.
+    pub fn has_operation(&self, ext_id: &str, operation: &str) -> bool {
+        self.extensions.get(ext_id).is_some_and(|ext| {
+            ext.operations().iter().any(|op| op.name == operation)
+        })
+    }
+}
+
+impl Default for ExtensionRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src-tauri/src/extensions/validation.rs
+++ b/src-tauri/src/extensions/validation.rs
@@ -1,0 +1,67 @@
+use jsonschema::Validator;
+use serde_json::Value;
+
+/// Validate a JSON value against a JSON Schema.
+/// Returns Ok(()) if valid, Err with a human-readable error message if invalid.
+pub fn validate_input(schema: &Value, input: &Value) -> Result<(), String> {
+    let validator = Validator::new(schema)
+        .map_err(|e| format!("Invalid schema: {}", e))?;
+
+    validator
+        .validate(input)
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_valid_input() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"]
+        });
+        let input = json!({ "name": "test" });
+        assert!(validate_input(&schema, &input).is_ok());
+    }
+
+    #[test]
+    fn test_missing_required_field() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"]
+        });
+        let input = json!({});
+        assert!(validate_input(&schema, &input).is_err());
+    }
+
+    #[test]
+    fn test_wrong_type() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "count": { "type": "integer" }
+            }
+        });
+        let input = json!({ "count": "not a number" });
+        assert!(validate_input(&schema, &input).is_err());
+    }
+
+    #[test]
+    fn test_empty_object_valid() {
+        let schema = json!({
+            "type": "object",
+            "properties": {}
+        });
+        let input = json!({});
+        assert!(validate_input(&schema, &input).is_ok());
+    }
+}

--- a/src-tauri/src/host_api/extensions.rs
+++ b/src-tauri/src/host_api/extensions.rs
@@ -1,0 +1,230 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Extension, Json,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::extensions::registry::ExtensionInfo;
+use crate::extensions::validation::validate_input;
+use crate::extensions::RiskLevel;
+use crate::permissions::Permission;
+use crate::AppState;
+
+use super::approval::ApprovalBridge;
+use super::middleware::AuthenticatedPlugin;
+
+/// Response for GET /v1/extensions
+#[derive(Serialize)]
+pub struct ListExtensionsResponse {
+    pub extensions: Vec<ExtensionInfo>,
+}
+
+/// Request body for POST /v1/extensions/{ext_id}/{operation}
+#[derive(Deserialize)]
+pub struct CallExtensionRequest {
+    #[serde(default = "default_input")]
+    pub input: Value,
+}
+
+fn default_input() -> Value {
+    Value::Object(serde_json::Map::new())
+}
+
+/// Response for POST /v1/extensions/{ext_id}/{operation}
+#[derive(Serialize)]
+pub struct CallExtensionResponse {
+    pub success: bool,
+    pub data: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// Error response body
+#[derive(Serialize)]
+pub struct ExtensionErrorResponse {
+    pub error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
+}
+
+fn error_response(status: StatusCode, error: &str, details: Option<String>) -> (StatusCode, Json<ExtensionErrorResponse>) {
+    (
+        status,
+        Json(ExtensionErrorResponse {
+            error: error.to_string(),
+            details,
+        }),
+    )
+}
+
+/// GET /v1/extensions — list all registered extensions and their operations.
+pub async fn list_extensions(
+    State(state): State<AppState>,
+    Extension(_auth): Extension<AuthenticatedPlugin>,
+) -> Json<ListExtensionsResponse> {
+    let mgr = state.read().await;
+    let extensions = mgr.extensions.list();
+    Json(ListExtensionsResponse { extensions })
+}
+
+/// POST /v1/extensions/{ext_id}/{operation} — execute an extension operation.
+///
+/// Permission checking is done in the handler (not middleware) because the
+/// required permission scope is dynamic based on path parameters.
+pub async fn call_extension(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthenticatedPlugin>,
+    Extension(bridge): Extension<Arc<ApprovalBridge>>,
+    Path((ext_id, operation)): Path<(String, String)>,
+    Json(body): Json<CallExtensionRequest>,
+) -> Result<Json<CallExtensionResponse>, (StatusCode, Json<ExtensionErrorResponse>)> {
+    let mgr = state.read().await;
+
+    // 1. Look up extension
+    let ext = mgr.extensions.get(&ext_id).ok_or_else(|| {
+        error_response(
+            StatusCode::NOT_FOUND,
+            "Extension not found",
+            Some(format!("No extension with ID '{}'", ext_id)),
+        )
+    })?;
+
+    // 2. Look up operation
+    let op_def = ext
+        .operations()
+        .into_iter()
+        .find(|op| op.name == operation)
+        .ok_or_else(|| {
+            error_response(
+                StatusCode::NOT_FOUND,
+                "Operation not found",
+                Some(format!(
+                    "Extension '{}' has no operation '{}'",
+                    ext_id, operation
+                )),
+            )
+        })?;
+
+    // 3. Check permission: "ext:{ext_id}:{operation}"
+    let perm_string = crate::extensions::registry::ExtensionRegistry::permission_string(&ext_id, &operation);
+    let required_perm = Permission::Extension(perm_string.clone());
+
+    if !mgr.permissions.has_permission(&auth.plugin_id, &required_perm) {
+        log::warn!(
+            "AUDIT DENIED plugin={} extension={} operation={} reason=missing_permission perm={}",
+            auth.plugin_id,
+            ext_id,
+            operation,
+            perm_string,
+        );
+        return Err(error_response(
+            StatusCode::FORBIDDEN,
+            "Permission denied",
+            Some(format!("Plugin '{}' lacks permission '{}'", auth.plugin_id, perm_string)),
+        ));
+    }
+
+    // 4. Validate input against the operation's JSON Schema
+    validate_input(&op_def.input_schema, &body.input).map_err(|e| {
+        error_response(
+            StatusCode::BAD_REQUEST,
+            "Invalid input",
+            Some(e),
+        )
+    })?;
+
+    // 5. Runtime approval for high-risk operations
+    if op_def.risk_level == RiskLevel::High {
+        let mut context = std::collections::HashMap::new();
+        context.insert("extension".to_string(), ext_id.clone());
+        context.insert("operation".to_string(), operation.clone());
+        context.insert("risk_level".to_string(), "high".to_string());
+        // Include a summary of the input for the approval dialog
+        if let Value::Object(map) = &body.input {
+            for (k, v) in map {
+                context.insert(format!("input.{}", k), v.to_string());
+            }
+        }
+
+        let request = super::approval::ApprovalRequest {
+            id: uuid::Uuid::new_v4().to_string(),
+            plugin_id: auth.plugin_id.clone(),
+            plugin_name: auth.plugin_id.clone(),
+            category: format!("extension:{}", ext_id),
+            permission: perm_string.clone(),
+            context,
+        };
+
+        // Drop the read lock before awaiting approval (which can take up to 60s)
+        drop(mgr);
+
+        match bridge.request_approval(request).await {
+            super::approval::ApprovalDecision::Approve
+            | super::approval::ApprovalDecision::ApproveOnce => {
+                // Re-acquire read lock
+                let mgr = state.read().await;
+                let ext = mgr.extensions.get(&ext_id).ok_or_else(|| {
+                    error_response(StatusCode::INTERNAL_SERVER_ERROR, "Extension disappeared", None)
+                })?;
+
+                let result = ext.execute(&operation, body.input).await.map_err(|e| {
+                    log::error!(
+                        "Extension error: ext={} op={} plugin={} error={}",
+                        ext_id, operation, auth.plugin_id, e
+                    );
+                    error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Extension execution failed",
+                        Some(e.to_string()),
+                    )
+                })?;
+
+                log::info!(
+                    "AUDIT plugin={} extension={} operation={} status=200",
+                    auth.plugin_id, ext_id, operation
+                );
+
+                return Ok(Json(CallExtensionResponse {
+                    success: result.success,
+                    data: result.data,
+                    message: result.message,
+                }));
+            }
+            super::approval::ApprovalDecision::Deny => {
+                return Err(error_response(
+                    StatusCode::FORBIDDEN,
+                    "Runtime approval denied",
+                    Some("User denied the high-risk operation".to_string()),
+                ));
+            }
+        }
+    }
+
+    // 6. Execute (non-high-risk path, or low/medium risk)
+    let result = ext.execute(&operation, body.input).await.map_err(|e| {
+        log::error!(
+            "Extension error: ext={} op={} plugin={} error={}",
+            ext_id, operation, auth.plugin_id, e
+        );
+        error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Extension execution failed",
+            Some(e.to_string()),
+        )
+    })?;
+
+    log::info!(
+        "AUDIT plugin={} extension={} operation={} status=200",
+        auth.plugin_id, ext_id, operation
+    );
+
+    Ok(Json(CallExtensionResponse {
+        success: result.success,
+        data: result.data,
+        message: result.message,
+    }))
+}

--- a/src-tauri/src/host_api/mcp.rs
+++ b/src-tauri/src/host_api/mcp.rs
@@ -105,12 +105,12 @@ pub async fn list_tools(State(state): State<AppState>) -> Json<Vec<McpToolEntry>
 
         for tool in &mcp_config.tools {
             let tool_disabled = plugin_mcp
-                .map_or(false, |s| s.disabled_tools.contains(&tool.name));
+                .is_some_and(|s| s.disabled_tools.contains(&tool.name));
 
             // Check permissions
             let all_perms_granted = tool.permissions.iter().all(|perm_str| {
                 serde_json::from_value::<Permission>(serde_json::Value::String(perm_str.clone()))
-                    .map_or(false, |perm| {
+                    .is_ok_and(|perm| {
                         mgr.permissions.has_permission(&plugin.manifest.id, &perm)
                     })
             });
@@ -191,7 +191,7 @@ pub async fn call_tool(
     }
 
     // Check tool not disabled
-    let tool_disabled = plugin_mcp.map_or(false, |s| s.disabled_tools.contains(&local_name));
+    let tool_disabled = plugin_mcp.is_some_and(|s| s.disabled_tools.contains(&local_name));
     if tool_disabled {
         return Err(StatusCode::FORBIDDEN);
     }

--- a/src-tauri/src/host_api/mod.rs
+++ b/src-tauri/src/host_api/mod.rs
@@ -1,5 +1,6 @@
 pub mod approval;
 pub mod docker;
+pub mod extensions;
 pub mod filesystem;
 pub mod mcp;
 mod middleware;
@@ -104,6 +105,15 @@ pub async fn start_server(
         )
         // Network
         .route("/v1/network/proxy", routing::post(network::proxy_request))
+        // Extensions
+        .route(
+            "/v1/extensions",
+            routing::get(extensions::list_extensions),
+        )
+        .route(
+            "/v1/extensions/{ext_id}/{operation}",
+            routing::post(extensions::call_extension),
+        )
         // Plugin settings (scoped to authenticated plugin)
         .route(
             "/v1/settings",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod error;
+pub mod extensions;
 pub mod host_api;
 mod permissions;
 mod plugin_manager;
@@ -91,6 +92,7 @@ pub fn run() {
             commands::mcp::mcp_set_enabled,
             commands::mcp::mcp_list_tools,
             commands::mcp::mcp_config_snippet,
+            commands::extensions::extension_list,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/permissions/checker.rs
+++ b/src-tauri/src/permissions/checker.rs
@@ -1,6 +1,7 @@
 use super::types::Permission;
 use super::store::PermissionStore;
 
+#[allow(dead_code)]
 pub fn check_permission(
     store: &PermissionStore,
     plugin_id: &str,
@@ -27,6 +28,8 @@ pub fn required_permission_for_endpoint(path: &str) -> Option<Permission> {
         p if p.starts_with("/v1/network/") => None,
         // Settings require auth (via middleware token check) but no specific permission
         p if p.starts_with("/v1/settings") => None,
+        // Extension permissions are checked in the handler (dynamic based on path params)
+        p if p.starts_with("/v1/extensions") => None,
         _ => None,
     }
 }

--- a/src-tauri/src/permissions/types.rs
+++ b/src-tauri/src/permissions/types.rs
@@ -1,27 +1,53 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+/// Known permission variants plus dynamic extension permissions.
+///
+/// Extension permissions use the format "ext:{extension_id}:{operation_name}",
+/// e.g. "ext:weather:get_forecast". They are stored as `Extension(String)`
+/// and serialized/deserialized with a custom impl to avoid ambiguity with the
+/// known string variants.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Permission {
-    #[serde(rename = "system:info")]
     SystemInfo,
-    #[serde(rename = "filesystem:read")]
     FilesystemRead,
-    #[serde(rename = "filesystem:write")]
     FilesystemWrite,
-    #[serde(rename = "process:list")]
     ProcessList,
-    #[serde(rename = "docker:read")]
     DockerRead,
-    #[serde(rename = "docker:manage")]
     DockerManage,
-    #[serde(rename = "network:local")]
     NetworkLocal,
-    #[serde(rename = "network:internet")]
     NetworkInternet,
+    /// Dynamic extension permission: "ext:{ext_id}:{operation}"
+    Extension(String),
 }
 
+/// All known permission string values (excluding dynamic Extension variants).
+const KNOWN_PERMISSIONS: &[&str] = &[
+    "system:info",
+    "filesystem:read",
+    "filesystem:write",
+    "process:list",
+    "docker:read",
+    "docker:manage",
+    "network:local",
+    "network:internet",
+];
+
 impl Permission {
+    /// The serialized string form of this permission.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Permission::SystemInfo => "system:info",
+            Permission::FilesystemRead => "filesystem:read",
+            Permission::FilesystemWrite => "filesystem:write",
+            Permission::ProcessList => "process:list",
+            Permission::DockerRead => "docker:read",
+            Permission::DockerManage => "docker:manage",
+            Permission::NetworkLocal => "network:local",
+            Permission::NetworkInternet => "network:internet",
+            Permission::Extension(s) => s.as_str(),
+        }
+    }
+
     pub fn risk_level(&self) -> &'static str {
         match self {
             Permission::SystemInfo => "low",
@@ -32,10 +58,12 @@ impl Permission {
             Permission::DockerManage => "high",
             Permission::NetworkLocal => "medium",
             Permission::NetworkInternet => "medium",
+            // Extension permissions derive risk from the operation; default to medium
+            Permission::Extension(_) => "medium",
         }
     }
 
-    pub fn description(&self) -> &'static str {
+    pub fn description(&self) -> &str {
         match self {
             Permission::SystemInfo => "Read OS info, hostname, uptime",
             Permission::FilesystemRead => "Read files on approved paths",
@@ -45,7 +73,44 @@ impl Permission {
             Permission::DockerManage => "Start/stop/create containers",
             Permission::NetworkLocal => "HTTP requests to LAN",
             Permission::NetworkInternet => "HTTP requests to internet",
+            Permission::Extension(s) => s.as_str(),
         }
+    }
+}
+
+impl Serialize for Permission {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Permission {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "system:info" => Ok(Permission::SystemInfo),
+            "filesystem:read" => Ok(Permission::FilesystemRead),
+            "filesystem:write" => Ok(Permission::FilesystemWrite),
+            "process:list" => Ok(Permission::ProcessList),
+            "docker:read" => Ok(Permission::DockerRead),
+            "docker:manage" => Ok(Permission::DockerManage),
+            "network:local" => Ok(Permission::NetworkLocal),
+            "network:internet" => Ok(Permission::NetworkInternet),
+            _ if s.starts_with("ext:") => Ok(Permission::Extension(s)),
+            _ => Err(serde::de::Error::unknown_variant(&s, KNOWN_PERMISSIONS)),
+        }
+    }
+}
+
+impl std::fmt::Display for Permission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 

--- a/src-tauri/src/plugin_manager/mod.rs
+++ b/src-tauri/src/plugin_manager/mod.rs
@@ -5,6 +5,7 @@ pub mod registry;
 pub mod storage;
 
 use crate::error::{NexusError, NexusResult};
+use crate::extensions::registry::ExtensionRegistry;
 use crate::permissions::PermissionStore;
 use manifest::PluginManifest;
 use storage::{
@@ -19,6 +20,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub struct PluginManager {
     pub storage: PluginStorage,
     pub permissions: PermissionStore,
+    pub extensions: ExtensionRegistry,
     pub registry_store: registry::RegistryStore,
     pub registry_cache: Vec<registry::RegistryEntry>,
     pub settings: NexusSettings,
@@ -61,6 +63,7 @@ impl PluginManager {
         PluginManager {
             storage,
             permissions,
+            extensions: ExtensionRegistry::new(),
             registry_store,
             registry_cache: Vec::new(),
             settings,
@@ -116,9 +119,9 @@ impl PluginManager {
             .collect();
         env_vars.push(format!("NEXUS_TOKEN={}", token));
         // Browser-accessible URL — the iframe JS runs in the host browser, not inside the container
-        env_vars.push(format!("NEXUS_API_URL=http://localhost:9600"));
+        env_vars.push("NEXUS_API_URL=http://localhost:9600".to_string());
         // Container-internal URL — for server-side code (MCP handlers etc.) that runs inside Docker
-        env_vars.push(format!("NEXUS_HOST_URL=http://host.docker.internal:9600"));
+        env_vars.push("NEXUS_HOST_URL=http://host.docker.internal:9600".to_string());
 
         // Labels for tracking
         let mut labels = HashMap::new();

--- a/src-tauri/src/plugin_manager/registry.rs
+++ b/src-tauri/src/plugin_manager/registry.rs
@@ -61,8 +61,7 @@ impl RegistryStore {
             store.path = path;
             Ok(store)
         } else {
-            let mut store = RegistryStore::default();
-            store.path = path;
+            let store = RegistryStore { path, ..Default::default() };
             store.save()?;
             Ok(store)
         }

--- a/src/components/permissions/PermissionList.tsx
+++ b/src/components/permissions/PermissionList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { usePermissions } from "../../hooks/usePermissions";
-import { PERMISSION_INFO } from "../../types/permissions";
+import { getPermissionInfo } from "../../types/permissions";
 import type { Permission } from "../../types/permissions";
 import { ChevronDown, FolderOpen, X } from "lucide-react";
 
@@ -36,7 +36,7 @@ export function PermissionList({ pluginId }: Props) {
   return (
     <div className="space-y-1.5">
       {grants.map((grant) => {
-        const info = PERMISSION_INFO[grant.permission as Permission];
+        const info = getPermissionInfo(grant.permission);
         const isFs = FS_PERMISSIONS.includes(grant.permission);
         const hasPaths =
           isFs &&

--- a/src/components/settings/ExtensionsTab.tsx
+++ b/src/components/settings/ExtensionsTab.tsx
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useState } from "react";
+import { extensionList } from "../../lib/tauri";
+import type { ExtensionStatus } from "../../types/extension";
+import {
+  Blocks,
+  ChevronDown,
+  Shield,
+  ShieldAlert,
+  Puzzle,
+} from "lucide-react";
+
+const RISK_STYLES: Record<string, { bg: string; text: string }> = {
+  low: { bg: "bg-nx-success-muted", text: "text-nx-success" },
+  medium: { bg: "bg-nx-warning-muted", text: "text-nx-warning" },
+  high: { bg: "bg-nx-error-muted", text: "text-nx-error" },
+};
+
+export function ExtensionsTab() {
+  const [extensions, setExtensions] = useState<ExtensionStatus[]>([]);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const exts = await extensionList();
+      setExtensions(exts);
+    } catch {
+      // backend may not have extension commands yet
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  function toggleExpanded(extId: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(extId)) {
+        next.delete(extId);
+      } else {
+        next.add(extId);
+      }
+      return next;
+    });
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <section className="bg-nx-surface rounded-[var(--radius-card)] border border-nx-border p-5">
+          <p className="text-[12px] text-nx-text-ghost">
+            Loading extensions...
+          </p>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <section className="bg-nx-surface rounded-[var(--radius-card)] border border-nx-border p-5">
+        <div className="flex items-center gap-2 mb-2">
+          <Blocks size={15} strokeWidth={1.5} className="text-nx-text-muted" />
+          <h3 className="text-[14px] font-semibold text-nx-text">
+            Host Extensions
+          </h3>
+        </div>
+        <p className="text-[11px] text-nx-text-ghost">
+          Extensions run trusted code on the host and expose typed, validated
+          operations to plugins. Plugins consume extensions through the Host API
+          to perform privileged tasks like credential management and cache
+          control.
+        </p>
+        <div className="mt-3 flex items-center gap-2">
+          <span className="text-[11px] text-nx-text-muted font-medium">
+            {extensions.length} extension{extensions.length !== 1 ? "s" : ""}{" "}
+            registered
+          </span>
+        </div>
+      </section>
+
+      {/* Extension cards */}
+      {extensions.length === 0 ? (
+        <section className="bg-nx-surface rounded-[var(--radius-card)] border border-nx-border p-5">
+          <p className="text-[12px] text-nx-text-ghost">
+            No extensions registered.
+          </p>
+        </section>
+      ) : (
+        extensions.map((ext) => {
+          const isOpen = expanded.has(ext.id);
+          return (
+            <section
+              key={ext.id}
+              className="bg-nx-surface rounded-[var(--radius-card)] border border-nx-border overflow-hidden"
+            >
+              {/* Extension header */}
+              <button
+                onClick={() => toggleExpanded(ext.id)}
+                className="w-full flex items-center justify-between p-5 hover:bg-nx-wash/20 transition-colors"
+              >
+                <div className="min-w-0 flex-1 text-left">
+                  <div className="flex items-center gap-2 mb-1">
+                    <h4 className="text-[13px] font-semibold text-nx-text">
+                      {ext.display_name}
+                    </h4>
+                    <span className="text-[10px] text-nx-text-ghost font-mono">
+                      {ext.id}
+                    </span>
+                  </div>
+                  <p className="text-[11px] text-nx-text-ghost">
+                    {ext.description}
+                  </p>
+                  <div className="flex items-center gap-3 mt-2">
+                    <span className="text-[10px] text-nx-text-muted">
+                      {ext.operations.length} operation
+                      {ext.operations.length !== 1 ? "s" : ""}
+                    </span>
+                    {ext.consumers.length > 0 && (
+                      <span className="text-[10px] text-nx-text-muted">
+                        {ext.consumers.length} plugin
+                        {ext.consumers.length !== 1 ? "s" : ""}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <ChevronDown
+                  size={14}
+                  strokeWidth={1.5}
+                  className={`text-nx-text-ghost transition-transform duration-200 flex-shrink-0 ml-3 ${
+                    isOpen ? "rotate-180" : ""
+                  }`}
+                />
+              </button>
+
+              {/* Expanded detail */}
+              {isOpen && (
+                <div className="border-t border-nx-border">
+                  {/* Operations */}
+                  <div className="p-4">
+                    <div className="flex items-center gap-2 mb-3">
+                      <Blocks
+                        size={12}
+                        strokeWidth={1.5}
+                        className="text-nx-text-ghost"
+                      />
+                      <span className="text-[11px] font-semibold text-nx-text-muted uppercase tracking-wide">
+                        Operations
+                      </span>
+                    </div>
+                    <div className="space-y-1">
+                      {ext.operations.map((op) => {
+                        const risk =
+                          RISK_STYLES[op.risk_level] ?? RISK_STYLES.medium;
+                        return (
+                          <div
+                            key={op.name}
+                            className="flex items-center gap-3 px-3 py-2 rounded-[var(--radius-button)] bg-nx-deep border border-nx-border-subtle"
+                          >
+                            <span className="text-[12px] text-nx-text font-mono min-w-0 flex-shrink-0">
+                              {op.name}
+                            </span>
+                            <span
+                              className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-[var(--radius-tag)] flex-shrink-0 ${risk.bg} ${risk.text}`}
+                            >
+                              {op.risk_level}
+                            </span>
+                            <span className="text-[11px] text-nx-text-ghost truncate min-w-0 flex-1">
+                              {op.description}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {/* Plugin consumers */}
+                  <div className="px-4 pb-4">
+                    <div className="flex items-center gap-2 mb-3">
+                      <Puzzle
+                        size={12}
+                        strokeWidth={1.5}
+                        className="text-nx-text-ghost"
+                      />
+                      <span className="text-[11px] font-semibold text-nx-text-muted uppercase tracking-wide">
+                        Plugin Consumers
+                      </span>
+                    </div>
+                    {ext.consumers.length === 0 ? (
+                      <p className="text-[11px] text-nx-text-ghost px-3">
+                        No plugins using this extension.
+                      </p>
+                    ) : (
+                      <div className="space-y-1">
+                        {ext.consumers.map((consumer) => (
+                          <div
+                            key={consumer.plugin_id}
+                            className="flex items-center gap-3 px-3 py-2 rounded-[var(--radius-button)] bg-nx-deep border border-nx-border-subtle"
+                          >
+                            <span className="text-[12px] text-nx-text font-medium truncate flex-1">
+                              {consumer.plugin_name}
+                            </span>
+                            <span className="relative group flex-shrink-0">
+                              {consumer.granted ? (
+                                <Shield
+                                  size={12}
+                                  strokeWidth={1.5}
+                                  className="text-nx-success cursor-help"
+                                />
+                              ) : (
+                                <ShieldAlert
+                                  size={12}
+                                  strokeWidth={1.5}
+                                  className="text-nx-warning cursor-help"
+                                />
+                              )}
+                              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-[10px] font-medium text-nx-text bg-nx-surface border border-nx-border rounded-[var(--radius-tag)] shadow-sm whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity duration-150 z-10">
+                                {consumer.granted
+                                  ? "All extension permissions granted"
+                                  : "Some extension permissions missing"}
+                              </span>
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </section>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -5,10 +5,11 @@ import { ResourcesTab } from "./ResourcesTab";
 import { PluginsTab } from "./PluginsTab";
 import { PermissionsTab } from "./PermissionsTab";
 import { McpTab } from "./McpTab";
-import { Settings, Container, Gauge, Puzzle, Shield, Cpu } from "lucide-react";
+import { ExtensionsTab } from "./ExtensionsTab";
+import { Settings, Container, Gauge, Puzzle, Shield, Cpu, Blocks } from "lucide-react";
 import { ErrorBoundary } from "../ErrorBoundary";
 
-type SettingsTab = "general" | "runtime" | "resources" | "plugins" | "permissions" | "mcp";
+type SettingsTab = "general" | "runtime" | "resources" | "plugins" | "permissions" | "mcp" | "extensions";
 
 const TABS: { id: SettingsTab; label: string; icon: typeof Settings }[] = [
   { id: "general", label: "General", icon: Settings },
@@ -17,6 +18,7 @@ const TABS: { id: SettingsTab; label: string; icon: typeof Settings }[] = [
   { id: "plugins", label: "Plugins", icon: Puzzle },
   { id: "permissions", label: "Permissions", icon: Shield },
   { id: "mcp", label: "MCP", icon: Cpu },
+  { id: "extensions", label: "Extensions", icon: Blocks },
 ];
 
 export function SettingsPage() {
@@ -62,6 +64,7 @@ export function SettingsPage() {
           {active === "plugins" && <PluginsTab />}
           {active === "permissions" && <PermissionsTab />}
           {active === "mcp" && <McpTab />}
+          {active === "extensions" && <ExtensionsTab />}
         </ErrorBoundary>
       </div>
     </div>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -202,6 +202,14 @@ export async function registryToggle(
   return invoke("registry_toggle", { id, enabled });
 }
 
+// Extensions
+
+import type { ExtensionStatus } from "../types/extension";
+
+export async function extensionList(): Promise<ExtensionStatus[]> {
+  return invoke("extension_list");
+}
+
 // MCP Gateway
 
 export async function mcpGetSettings(): Promise<McpSettings> {

--- a/src/types/extension.ts
+++ b/src/types/extension.ts
@@ -1,0 +1,19 @@
+export interface ExtensionOperation {
+  name: string;
+  description: string;
+  risk_level: "low" | "medium" | "high";
+}
+
+export interface ExtensionConsumer {
+  plugin_id: string;
+  plugin_name: string;
+  granted: boolean;
+}
+
+export interface ExtensionStatus {
+  id: string;
+  display_name: string;
+  description: string;
+  operations: ExtensionOperation[];
+  consumers: ExtensionConsumer[];
+}

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -38,6 +38,7 @@ export interface PluginManifest {
   min_nexus_version?: string;
   settings?: SettingDef[];
   mcp?: McpConfig;
+  extensions?: Record<string, string[]>;
 }
 
 export interface InstalledPlugin {


### PR DESCRIPTION
## Summary

- Adds a generic **host extension framework** in Rust: trait-based `Extension` with async operations, an `ExtensionRegistry`, and input validation — enabling plugins to call host-side operations through `POST /api/v1/extensions/{ext_id}/{operation}` with permission gating via `ext:{ext_id}:{operation}` scopes
- Extends the **permission system** to support dynamic `ext:*` permission strings with auto-generated metadata, and adds `allPermissions()` to compute the full permission set from a manifest's `extensions` map
- Adds a **scroll-to-bottom gate** on the permission review step so users must see every requested permission before they can approve
- Adds a **Settings > Extensions** tab showing registered host extensions and which plugins consume them
- Adds Tauri command plumbing (`extension_list`) and TypeScript types for the frontend

## Test plan

- [ ] `cargo build` in `src-tauri/` — framework compiles with no concrete extensions registered
- [ ] `pnpm build` — frontend compiles with new permission types and components
- [ ] Install a plugin with `extensions` in its manifest → permission dialog shows all `ext:*` permissions with risk badges
- [ ] Permissions list overflows → scroll required before "Approve" / "Review MCP Tools" button enables
- [ ] Plugin with few permissions → button enables immediately (no unnecessary gate)
- [ ] Settings > Extensions tab renders (empty state when no extensions registered)
- [ ] `PermissionList` for installed plugins renders `ext:*` grants with description