### PR TITLE
fix: capitalize tray icon text and tag dev builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,11 @@ pub fn run() {
                         .level(log::LevelFilter::Info)
                         .build(),
                 )?;
+
+                // Tag window title so dev builds are visually distinct
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.set_title("Nexus (dev)");
+                }
             }
 
             let app_handle = app.handle().clone();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,6 +26,8 @@
       "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:* https://raw.githubusercontent.com; frame-src http://localhost:*"
     },
     "trayIcon": {
+      "title": "Nexus",
+      "tooltip": "Nexus",
       "iconPath": "icons/32x32.png",
       "iconAsTemplate": true
     }


### PR DESCRIPTION
## Summary
- Set `title` and `tooltip` on tray icon config so it displays "Nexus" instead of the lowercase Cargo binary name
- In debug builds, set the window title to "Nexus (dev)" so dev and production instances are visually distinct

## Test plan
- [ ] `pnpm tauri dev` — window title shows "Nexus (dev)", tray tooltip shows "Nexus"
- [ ] Production build — window title shows "Nexus", tray tooltip shows "Nexus"