### PR TITLE
fix(mcp-bridge): use Zod request schemas instead of plain objects

### DIFF
--- a/tools/mcp-bridge/src/server.js
+++ b/tools/mcp-bridge/src/server.js
@@ -4,6 +4,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 
 const PORT = 80;
 const MCP_SERVER_COMMAND = process.env.MCP_SERVER_COMMAND;
@@ -57,7 +65,7 @@ function createBridgeServer() {
 
   // Dynamic tool listing — forward from child
   server.server.setRequestHandler(
-    { method: "tools/list" },
+    ListToolsRequestSchema,
     async () => {
       if (!childClient) throw new Error("Child MCP client not initialized");
       return childClient.listTools();
@@ -66,7 +74,7 @@ function createBridgeServer() {
 
   // Tool calls — forward to child
   server.server.setRequestHandler(
-    { method: "tools/call" },
+    CallToolRequestSchema,
     async (request) => {
       if (!childClient) throw new Error("Child MCP client not initialized");
       return childClient.callTool(request.params);
@@ -75,7 +83,7 @@ function createBridgeServer() {
 
   // Resource listing — forward from child (best-effort)
   server.server.setRequestHandler(
-    { method: "resources/list" },
+    ListResourcesRequestSchema,
     async () => {
       if (!childClient) throw new Error("Child MCP client not initialized");
       try {
@@ -88,7 +96,7 @@ function createBridgeServer() {
 
   // Resource reading — forward to child
   server.server.setRequestHandler(
-    { method: "resources/read" },
+    ReadResourceRequestSchema,
     async (request) => {
       if (!childClient) throw new Error("Child MCP client not initialized");
       return childClient.readResource(request.params);
@@ -97,7 +105,7 @@ function createBridgeServer() {
 
   // Prompt listing — forward from child (best-effort)
   server.server.setRequestHandler(
-    { method: "prompts/list" },
+    ListPromptsRequestSchema,
     async () => {
       if (!childClient) throw new Error("Child MCP client not initialized");
       try {
@@ -110,7 +118,7 @@ function createBridgeServer() {
 
   // Prompt retrieval — forward to child
   server.server.setRequestHandler(
-    { method: "prompts/get" },
+    GetPromptRequestSchema,
     async (request) => {
       if (!childClient) throw new Error("Child MCP client not initialized");
       return childClient.getPrompt(request.params);


### PR DESCRIPTION
## Problem

The MCP bridge crashes when wrapping any MCP server with `@modelcontextprotocol/sdk` v1.26.0+:

```
Error: Schema is missing a method literal
    at Server.setRequestHandler (file:///app/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js:99:19)
    at createBridgeServer (file:///app/src/server.js:59:17)
```

## Root Cause

SDK v1.26.0 changed `server.setRequestHandler()` to require **Zod schema objects** that contain a `.method` Zod literal (e.g., `ListToolsRequestSchema`). The bridge was passing plain JS objects like `{ method: "tools/list" }`, which don't have the Zod metadata the SDK now validates.

## Fix

Import the proper Zod request schemas from `@modelcontextprotocol/sdk/types.js` and use them in all 6 `setRequestHandler()` calls:

| Before (broken) | After (fixed) |
|---|---|
| `{ method: "tools/list" }` | `ListToolsRequestSchema` |
| `{ method: "tools/call" }` | `CallToolRequestSchema` |
| `{ method: "resources/list" }` | `ListResourcesRequestSchema` |
| `{ method: "resources/read" }` | `ReadResourceRequestSchema` |
| `{ method: "prompts/list" }` | `ListPromptsRequestSchema` |
| `{ method: "prompts/get" }` | `GetPromptRequestSchema` |

## Testing

Reproduced with `npx -y @upstash/context7-mcp@latest` (Context7 v2.1.1). The bridge successfully discovers tools but crashes on the first HTTP request when `createBridgeServer()` is called.

After this fix, the bridge should correctly register all request handlers with the SDK's expected Zod schema format.

## Note

Since `server.js` is embedded at compile time via `include_str!()` in `src-tauri/src/mcp_wrap/generate.rs`, Nexus must be recompiled for this fix to take effect in new MCP wrapper plugins.